### PR TITLE
Add `.clang-format`.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,4 @@
+BasedOnStyle: Google
+IndentWidth: 4
+AccessModifierOffset: -4
+ColumnLimit: 120


### PR DESCRIPTION
## 概要
- cpp ファイルのフォーマッター用に `.clang-format` を追加

## Check List
- [x] 必要な変更のpush漏れが無い (`git status` や VSCode 等で確認)
- [x] 不必要な変更のpushが無い (`git status` や VSCode 等で確認)
- [x] VS Code にてcppファイルをフォーマットできる


## 動作確認手順（レビュワー再現用）
- `.vscode/settings.json` に下記を追加することで，cpp ファイル保存時に自動でフォーマットされる
    ```json
    "C_Cpp.intelliSenseEngine": "Tag Parser",
    "[cpp]": {
        "editor.defaultFormatter": "xaver.clang-format",
        "editor.formatOnSave": true,
        "diffEditor.ignoreTrimWhitespace": false,
    },
    ```